### PR TITLE
Moved definition of CookieJar.cookies because it caused TypeError on constructor

### DIFF
--- a/src/cookie-jar.mjs
+++ b/src/cookie-jar.mjs
@@ -5,6 +5,8 @@ import {paramError, CookieParseError} from "./errors.mjs";
 
 export default class CookieJar {
     constructor(file, flags = "rw", cookies, cookieIgnoreCallback) {
+        this.cookies = new Map();
+        
         if(file && typeof file !== "string")
             throw paramError("Second", "file", "new CookieJar()", "string");
         if(typeof flags !== "string")
@@ -22,7 +24,6 @@ export default class CookieJar {
             throw paramError("Fourth", "cookieIgnoreCallback", "new CookieJar()", "function");
         this.file = file;
         this.flags = flags;
-        this.cookies = new Map();
         this.cookieIgnoreCallback = cookieIgnoreCallback;
     }
     addCookie(cookie, fromURL) {


### PR DESCRIPTION
Creating new CookieJar instance while passing array of Cookies as third argument causes typeError
`new CookieJar('', 'r', cookies)`

```
(node:29588) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'get' of undefined
    at CookieJar.addCookie (\node_modules\node-fetch-cookies\src\cookie-jar.mjs:44:26)
    at \node_modules\node-fetch-cookies\src\cookie-jar.mjs:15:44
    at CoreMongooseArray.forEach (<anonymous>)
    at new CookieJar (\node_modules\node-fetch-cookies\src\cookie-jar.mjs:15:21)```