### PR TITLE
fix: split set-cookie header by attributes

### DIFF
--- a/src/cookie.mjs
+++ b/src/cookie.mjs
@@ -40,7 +40,7 @@ export default class Cookie {
         // if it is invalid an error will be raised
         const parsedURL = new url.URL(requestURL);
 
-        const splitted = str.split(/;\s*|;/);
+        const splitted = str.split(/;\s*/);
         [this.name, this.value] = splitN(splitted[0], "=", 1);
         if (!this.name)
             throw new CookieParseError(

--- a/src/cookie.mjs
+++ b/src/cookie.mjs
@@ -40,7 +40,7 @@ export default class Cookie {
         // if it is invalid an error will be raised
         const parsedURL = new url.URL(requestURL);
 
-        const splitted = str.split("; ");
+        const splitted = str.split(/;\s*|;/);
         [this.name, this.value] = splitN(splitted[0], "=", 1);
         if (!this.name)
             throw new CookieParseError(


### PR DESCRIPTION
There are some web servers that send set-cookie header with more than one space after semicolon or even without it. So with `;\s*|;` regex set-cookie header can be parsed correctly.