### PR TITLE
fix: deletion of content-type header after redirect

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -51,10 +51,10 @@ async function fetch(cookieJars, url, options) {
         (!Number.isSafeInteger(options.follow) || options.follow < 0)
     )
         throw new TypeError("options.follow is not a safe positive integer");
+    // copy Headers as well so we don't modify it
+    // or, if headers is an object, construct a Headers object from it
+    options.headers = new Headers(options.headers);
     if (cookies) {
-        // copy Headers as well so we don't modify it
-        // or, if headers is an object, construct a Headers object from it
-        options.headers = new Headers(options.headers);
         options.headers.append("cookie", cookies.slice(0, -2));
     }
     if (wantFollow) options.redirect = "manual";
@@ -87,7 +87,9 @@ async function fetch(cookieJars, url, options) {
         ) {
             options.method = "GET";
             delete options.body;
-            if (options.headers) options.headers.delete("content-length");
+            if (options.headers) {
+                options.headers.delete("content-length");
+            }
         }
         const location = result.headers.get("location");
         options.redirect = "follow";


### PR DESCRIPTION
I get the following error `TypeError: options.headers.delete is not a function` in `index.mjs:96` when I send first POST request with empty cookieJar, and recieve 302 redirect.
Because we don't have cookies we don't go through these lines of code: 
```
if (cookies) {
    ...
    options.headers = new Headers(options.headers);
    ...
}
```
So `options.headers` is not type of `Headers`, which leads to it doesn't have method `delete()`. We can solve this issue by doing the same line `options.headers = new Headers(options.headers);` before calling method `delete()`.